### PR TITLE
fix for monolog

### DIFF
--- a/tests/Environment/YourLogger.php
+++ b/tests/Environment/YourLogger.php
@@ -17,7 +17,7 @@ class YourLogger extends Logger
         $filename = sprintf('phpreflect-%s.log', date('Ymd'));
 
         $stream = new RotatingFileHandler("$tempDir/$filename", 30);
-        $stream->setFilenameFormat('{filename}-{date}', 'Ymd');
+        $stream->setFilenameFormat('{filename}-{date}', 'Y-m-d');
 
         $handlers = array($stream);
 

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -188,7 +188,6 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Bartlett\Reflect\Environment::getLogger
      * @runInSeparateProcess
-     * @expectedException PHPUnit_Framework_Error_Deprecated
      *
      * @return void
      */


### PR DESCRIPTION
revert 561360f2f0bdf9234424d2ccdcc267a311ac8536 which breaks with monolog < 1.20
And fixing the "deprecated" seems better