### PR TITLE
Bump PHP version to 5.5 and nikic/php-parser version to 3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.5.0",
         "ext-tokenizer": "*",
         "ext-pcre": "*",
         "ext-phar": "*",
@@ -25,7 +25,7 @@
         "ext-date": "*",
         "ext-reflection": "*",
         "sebastian/version": "~1.0|~2.0",
-        "nikic/php-parser": "~2.1",
+        "nikic/php-parser": "~3.1",
         "doctrine/collections": "~1.2",
         "symfony/event-dispatcher": "~2.5|~3.0",
         "symfony/finder": "~2.5|~3.0",


### PR DESCRIPTION
We want to use `nikic/php-parser=~3.1` so that we can parse PHP 7.1 syntax in our code. However, I don't know why `llaville/php-reflect` still pins `nikic/php-parser` to `~2.1` and this prevents us from doing the upgrade.