### PR TITLE
Raise minimal PHP version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.5",
         "ext-tokenizer": "*",
         "ext-pcre": "*",
         "ext-phar": "*",


### PR DESCRIPTION
Because for "phpdocumentor/reflection-docblock": "^3.0",
See https://packagist.org/packages/phpdocumentor/reflection-docblock#3.0.0